### PR TITLE
Add a way to configure the number of threads

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,6 @@ matrix:
   allow_failures:
   - rust: nightly
 script:
-- cargo fmt -- --write-mode=diff
+- cargo fmt -- --check
 - cargo build --verbose
 - cargo test --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,10 @@ rust:
   - stable
   - beta
   - nightly
-env:
-  - RUN=TEST
 script:
   - cargo test
 matrix:
   include:
-    - rust: nightly
-      env: RUN=RUSTFMT
+    - rust: stable
       before_script: rustup component add rustfmt-preview
       script: cargo fmt --all -- --check
-  allow_failures:
-    - rust: nightly
-      env: RUN=TEST

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,5 +9,6 @@ script:
 matrix:
   include:
     - rust: stable
+      env: RUN=RUSTFMT
       before_script: rustup component add rustfmt-preview
-      script: cargo fmt --all -- --check
+      script: cargo fmt --all -- --write-mode=diff

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,19 @@
 language: rust
-sudo: false
 cache: cargo
-before_script:
-- cargo install -f rustfmt
-- export PATH=$PATH:$HOME/.cargo/bin
 rust:
-- nightly
-- beta
-- stable
-matrix:
-  allow_failures:
-  - rust: nightly
+  - stable
+  - beta
+  - nightly
+env:
+  - RUN=TEST
 script:
-- cargo fmt -- --check
-- cargo build --verbose
-- cargo test --verbose
+  - cargo test
+matrix:
+  include:
+    - rust: nightly
+      env: RUN=RUSTFMT
+      before_script: rustup component add rustfmt-preview
+      script: cargo fmt --all -- --check
+  allow_failures:
+    - rust: nightly
+      env: RUN=TEST

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "par-map"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["Guillaume Pinot <texitoi@texitoi.eu>"]
 description = "Parallel map and flat_map."
 documentation = "https://docs.rs/par-map"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -68,17 +68,7 @@ pub trait ParMap: Iterator + Sized {
         B: Send + 'static,
         Self::Item: Send + 'static,
     {
-        let num_threads = num_cpus::get();
-        let mut res = Map {
-            pool: CpuPool::new(num_threads),
-            queue: VecDeque::new(),
-            iter: self,
-            f: Arc::new(f),
-        };
-        for _ in 0..num_threads * 2 {
-            res.spawn();
-        }
-        res
+        Map::with_nb_threads(self, f, num_cpus::get())
     }
 
     /// Creates an iterator that works like map, but flattens nested
@@ -106,18 +96,7 @@ pub trait ParMap: Iterator + Sized {
         U::Item: Send + 'static,
         Self::Item: Send + 'static,
     {
-        let num_threads = num_cpus::get();
-        let mut res = FlatMap {
-            pool: CpuPool::new(num_threads),
-            queue: VecDeque::new(),
-            iter: self,
-            f: Arc::new(f),
-            cur_iter: vec![].into_iter(),
-        };
-        for _ in 0..num_threads * 2 {
-            res.spawn();
-        }
-        res
+        FlatMap::with_nb_threads(self, f, num_cpus::get())
     }
 
     /// Creates an iterator that yields `Vec<Self::Item>` of size `nb`
@@ -194,6 +173,27 @@ pub trait ParMap: Iterator + Sized {
         };
         PackedFlatMap(Box::new(self.pack(nb).par_flat_map(f)))
     }
+
+    /// Configure the number of thread used.
+    /// If not set, the default is the number of cpus available
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use par_map::ParMap;
+    /// let a = [1, 2, 3];
+    /// let mut iter = a.iter().cloned().with_nb_threads(2).par_map(|x| 2 * x);
+    /// assert_eq!(iter.next(), Some(2));
+    /// assert_eq!(iter.next(), Some(4));
+    /// assert_eq!(iter.next(), Some(6));
+    /// assert_eq!(iter.next(), None);
+    /// ```
+    fn with_nb_threads(self, nb: usize) -> ParMapBuilder<Self> {
+        ParMapBuilder {
+            iter: self,
+            nb_threads: nb
+        }
+    }
 }
 impl<I: Iterator> ParMap for I {}
 
@@ -222,6 +222,19 @@ where
             }
         };
         self.queue.push_back(future);
+    }
+
+    fn with_nb_threads(iter: I, f: F, nb_thread: usize) -> Self {
+        let mut res = Map {
+            pool: CpuPool::new(nb_thread),
+            queue: VecDeque::new(),
+            iter: iter,
+            f: Arc::new(f),
+        };
+        for _ in 0..nb_thread * 2 {
+            res.spawn();
+        }
+        res
     }
 }
 impl<I: Iterator, B: Send + 'static, F> Iterator for Map<I, B, F>
@@ -272,6 +285,19 @@ where
             }
         };
         self.queue.push_back(future);
+    }
+    fn with_nb_threads(iter: I, f: F, nb_thread: usize) -> Self {
+        let mut res = FlatMap {
+            pool: CpuPool::new(nb_thread),
+            queue: VecDeque::new(),
+            iter: iter,
+            f: Arc::new(f),
+            cur_iter: vec![].into_iter(),
+        };
+        for _ in 0..nb_thread * 2 {
+            res.spawn();
+        }
+        res
     }
 }
 impl<I: Iterator, U: IntoIterator, F> Iterator for FlatMap<I, U, F>
@@ -324,4 +350,58 @@ pub_iterator_type! {
 pub_iterator_type! {
     #[doc="As `FlatMap` but packed."]
     PackedFlatMap['a, T] = Box<Iterator<Item = T> + 'a>
+}
+
+/// A builder used to configure the parallele work.
+///
+/// This struct is created by the `with_nb_threads()` method on
+/// `ParIter`.  See its documentation for more.
+#[must_use = "iterator adaptors are lazy and do nothing unless consumed"]
+pub struct ParMapBuilder<I> {
+    iter: I,
+    nb_threads: usize,
+}
+
+impl<I: Iterator> ParMapBuilder<I> {
+    /// # Example
+    ///
+    /// ```
+    /// use par_map::ParMap;
+    /// let a = [1, 2, 3];
+    /// let mut iter = a.iter().cloned().with_nb_threads(2).par_map(|x| 2 * x);
+    /// assert_eq!(iter.next(), Some(2));
+    /// assert_eq!(iter.next(), Some(4));
+    /// assert_eq!(iter.next(), Some(6));
+    /// assert_eq!(iter.next(), None);
+    /// ```
+    pub fn par_map<B, F>(self, f: F) -> Map<I, B, F>
+    where
+        F: Sync + Send + 'static + Fn(I::Item) -> B,
+        B: Send + 'static,
+        I::Item: Send + 'static,
+    {
+        Map::with_nb_threads(self.iter, f, self.nb_threads)
+    }
+
+    /// # Example
+    ///
+    /// ```
+    /// use par_map::ParMap;
+    /// let words = ["alpha", "beta", "gamma"];
+    /// let merged: String = words.iter()
+    ///     .cloned() // as items must be 'static
+    ///     .with_nb_threads(2)
+    ///     .par_flat_map(|s| s.chars()) // exactly as std::iter::Iterator::flat_map
+    ///     .collect();
+    /// assert_eq!(merged, "alphabetagamma");
+    /// ```
+    pub fn par_flat_map<U, F>(self, f: F) -> FlatMap<I, U, F>
+    where
+        F: Sync + Send + 'static + Fn(I::Item) -> U,
+        U: IntoIterator,
+        U::Item: Send + 'static,
+        I::Item: Send + 'static,
+    {
+        FlatMap::with_nb_threads(self.iter, f, self.nb_threads)
+    }
 }


### PR DESCRIPTION
add a `with_nb_threads` that creates a Builder used to configure the number of threads.

I'm not 100% convinced by the implementation since I had to define again all the `ParIter` methods in the `Builder` but it works.

I have not defined the methods `par_{packed}_packed_map` as for we they can be easily created by chaining the `pack` method.

we could also add the `pack` param in the builder bu it would break the api, so it's up to you (and well I don't really need it, so the less work the better :stuck_out_tongue_winking_eye: )

Note: it seems there had been a mistake in crates.io the version in crates.io was 0.1.2
even if the master version was 0.1.1